### PR TITLE
improve scaling of navigation bar

### DIFF
--- a/src/components/Navigation/navigation.jsx
+++ b/src/components/Navigation/navigation.jsx
@@ -1,14 +1,12 @@
 import React from 'react';
 import Search from '../Search/search';
-import Link from 'gatsby-link';
 
 const Navigation = ({ children }) => (
   <div className="flex flex-column flex-row-ns justify-left w-100 pa3 bg-blue">
     <h1 className="f3 w-100 w-20-ns white lh-title self-center ma0 mb2 ma0-ns">CraftBox</h1>
     <Search />
     <div className="self-center-ns w-20-ns tl tr-ns">
-      <Link className="f6 fw4 hover-white no-underline white-70 pr2" to="/">Catalog</Link>
-      <Link className="f6 fw4 hover-white no-underline white-70 pr2" to="/product">Inspiration</Link>
+      {children}
     </div>
   </div>
 );
@@ -16,7 +14,7 @@ const Navigation = ({ children }) => (
 export default Navigation;
 
 Navigation.propTypes = {
-children: React.ReactNode,
+  children: React.ReactNode,
 };
 
 Navigation.defaultProps = {

--- a/src/components/Navigation/navigation.jsx
+++ b/src/components/Navigation/navigation.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Search from '../Search/search';
+import Link from 'gatsby-link';
 
 const Navigation = ({ children }) => (
   <div className="flex flex-column flex-row-ns justify-left w-100 pa3 bg-blue">

--- a/src/components/Navigation/navigation.jsx
+++ b/src/components/Navigation/navigation.jsx
@@ -2,11 +2,12 @@ import React from 'react';
 import Search from '../Search/search';
 
 const Navigation = ({ children }) => (
-  <div className="dt w-100 pa3 bg-blue h3">
-    <h1 className="dtc-ns dt-row f3 w-20 white lh-title v-mid-l">CraftBox</h1>
+  <div className="flex flex-column flex-row-ns justify-left w-100 pa3 bg-blue">
+    <h1 className="f3 w-100 w-20-ns white lh-title self-center ma0 mb2 ma0-ns">CraftBox</h1>
     <Search />
-    <div className="dtc-ns dt-row v-mid-l tl tr-ns">
-      {children}
+    <div className="self-center-ns w-20-ns tl tr-ns">
+      <Link className="f6 fw4 hover-white no-underline white-70 pr2" to="/">Catalog</Link>
+      <Link className="f6 fw4 hover-white no-underline white-70 pr2" to="/product">Inspiration</Link>
     </div>
   </div>
 );
@@ -14,7 +15,7 @@ const Navigation = ({ children }) => (
 export default Navigation;
 
 Navigation.propTypes = {
-  children: React.ReactNode,
+children: React.ReactNode,
 };
 
 Navigation.defaultProps = {

--- a/src/components/Search/search.jsx
+++ b/src/components/Search/search.jsx
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 export default class Search extends Component {
   render() {
     return (
-      <div className="dtc w-60-ns w-100 v-mid-l">
+      <div className="w-60-ns w-100 v-mid-l mb2 ma0-ns self-center">
         <fieldset className="cf bn ma0 pa0">
           <div className="cf">
             <label className="clip" htmlFor="email-address">Email Address</label>


### PR DESCRIPTION
Primarily visual improvements with the navigation bar when viewed in mobile. Replace table/table-cell styling with flexbox

## Visual Changes
#### Before: 
![before](https://user-images.githubusercontent.com/5944973/28244922-6ba7db9c-6a2b-11e7-994d-cb1cfe3186e0.jpg)
#### After:

![after](https://user-images.githubusercontent.com/5944973/28244923-7e17ad34-6a2b-11e7-80ba-9cb21d5a16de.jpg)