### PR TITLE
Fix production setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ deploy:
   github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
   local_dir: public
   on:
-    branch: master
+    branch: fix-production-setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ deploy:
   github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
   local_dir: public
   on:
-    branch: fix-production-setup
+    branch: master

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  pathPrefix: '/craftbox',
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "react": "^15.6.1"
   },
   "scripts": {
-    "build": "gatsby build",
+    "build": "gatsby build --prefix-paths",
+    "build:dev": "gatsby build",
     "dev": "gatsby develop",
     "test": "echo No tests!"
   },


### PR DESCRIPTION
# Purpose
Fix the production setup.

# Implementation
- Configure Gatsby to prefix paths with `/craftbox` as that is what production's path is like

# Notes
To build production assets on your local machine, please use `yarn build:dev` instead of `yarn build`.